### PR TITLE
feat: home, tourinfo 페이지 기능추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,44 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
-
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<meta name="theme-color" content="#000000">
-	<!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
-    -->
-	<link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-	<!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b2218e359c3f09506fc9816aea792ec9"></script>
-	<title>React App</title>
-</head>
-
-<body>
-	<noscript>
-		You need to enable JavaScript to run this app.
-	</noscript>
-	<div id="root"></div>
-	<!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
-
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="부산 여행 투어 예약 서비스" />
+    <title>부산 투어</title>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=YOUR_KAKAO_APP_KEY"></script>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -4,10 +4,44 @@ import Layout from "./pages/Layout";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import TourInfo from "./pages/TourInfo";
+import TourInfoDetail from "./pages/TourInfoDetail";
 import NoPage from "./pages/NoPage";
 import { useAuthStore } from "./stores/authStore";
 import { authFetch } from "./api/authFetch";
 import "./styles/global.css";
+
+const tourinfo = [
+  {
+    idxx: 0, X: "35.1327125523986", Y: "129.11996768904595",
+    name: "2024 갑진년 정월대보름 달맞이 축제", date: "2024.04",
+    dateDetail: "일시 : 2024-02-24 ~ 2024-02-24",
+    src: "https://visitbusan.net/upload_data/board_data/BBS_0000009/170797624559010.jpg",
+    alt: "2024 갑진년 정월대보름 달맞이 축제", title: "2024 갑진년 정월대보름 달맞이 축제",
+    DateTime: "2024년 2월 24일 토요일 / 14:00~19:00", place: "용호 별빛공원",
+    content: "연희집단 The 광대, 판소리, 매직 벌룬쇼, 대붓 퍼포먼스, 한국무용, 대형 연날리기",
+  },
+  {
+    idxx: 1, X: "35.15535654920573", Y: "129.1220090625425",
+    name: "2024 제25회 수영전통달집놀이", date: "2024.04",
+    dateDetail: "일시 : 2024-02-24 ~ 2024-02-24",
+    src: "https://visitbusan.net/upload_data/board_data/BBS_0000009/170839502514330.jpg",
+    alt: "2024 제25회 수영전통달집놀이", title: "2024 제25회 수영전통달집놀이",
+    DateTime: "2024.2.24.(토) 14:00~18:20", place: "광안리해변",
+    content: "소망포 새해소망쓰기, 줄타기공연, 수영야류, 달집 태우기",
+    organizedBy: "수영구 / 주관 : (사)수영고적민속예술보존협회",
+  },
+  {
+    idxx: 2, X: "35.154665861498145", Y: "129.121826533405",
+    name: "[광안리 M 드론라이트쇼] 2월 공연 프로그램 안내", date: "2024.04",
+    dateDetail: "일시 : 2024-02-01 ~ 2024-02-29",
+    src: "https://visitbusan.net/upload_data/board_data/BBS_0000009/170737641034162.png",
+    alt: "[광안리 M 드론라이트쇼] 2월 공연 프로그램 안내",
+    title: "[광안리 M 드론라이트쇼] 2월 공연 프로그램 안내",
+    DateTime: "매주 토요일 19시, 21시", place: "광안리해변",
+    content: "드론 라이트쇼 / 기상상황에 따라 취소될 수 있습니다.",
+  },
+];
 
 function PrivateRoute({ children }) {
   const { isAuthenticated } = useAuthStore();
@@ -41,6 +75,8 @@ export default function App() {
           }
         >
           <Route index element={<Home />} />
+          <Route path="TourInfo" element={<TourInfo tourinfo={tourinfo} />} />
+          <Route path="TourInfoDetail/:idxx" element={<TourInfoDetail tourinfo={tourinfo} />} />
           <Route path="*" element={<NoPage />} />
         </Route>
       </Routes>

--- a/src/pages/TourInfo.js
+++ b/src/pages/TourInfo.js
@@ -1,194 +1,61 @@
 import React, { useState, useEffect } from "react";
-import {
-  useNavigate,
-  Link,
-} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
-function TourInfo({ tourinfo, setTourinfo, setNotice, member, setMember, position }) {
+const API_URL =
+  "https://apis.data.go.kr/B551011/KorService1/areaBasedList1?numOfRows=12&pageNo=1&MobileOS=ETC&MobileApp=AppTest&ServiceKey=ZlHtWroJ5vtZoCdZ24%2FYg25%2B%2F6l4ZCjrp19iGdmsJKQOng6tH28umr0KycuccrDvDy8ANWGyQHAO3iTL7Hdqyw%3D%3D&listYN=Y&arrange=A&contentTypeId=15&areaCode=6&sigunguCode=&cat1=&cat2=&cat3=&_type=json";
+
+export default function TourInfo({ tourinfo }) {
+  const [datas, setDatas] = useState([]);
+  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
-  const [tempTourInfo, setTempTourInfo] = useState(tourinfo);
-  const [datas, setDatas] = useState(tourinfo);
-  const [btnColor, setBtnColor] = useState();
-  const month = [
-    "전체",
-    "1월",
-    "2월",
-    "3월",
-    "4월",
-    "5월",
-    "6월",
-    "7월",
-    "8월",
-    "9월",
-    "10월",
-    "11월",
-    "12월",
-  ];
 
-  const styles = {
-    container: {
-      display: "grid",
-      gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-      gap: "20px",
-      padding: "20px",
-      backgroundColor: "#f9f9f9",
-    },
-    card: {
-      backgroundColor: "#fff",
-      borderRadius: "8px",
-      boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
-      overflow: "hidden",
-      transition: "transform 0.3s ease, box-shadow 0.3s ease",
-      textAlign: "center",
-    },
-    cardHover: {
-      transform: "scale(1.05)",
-      boxShadow: "0 6px 10px rgba(0, 0, 0, 0.15)",
-    },
-    image: {
-      width: "100%",
-      height: "150px",
-      objectFit: "cover",
-    },
-    text: {
-      padding: "15px",
-    },
-    title: {
-      fontSize: "18px",
-      margin: "10px 0 5px",
-      color: "#333",
-    },
-    description: {
-      fontSize: "14px",
-      color: "#666",
-    },
-  };
-  //(버튼색상)기본 #22B8CF, 선택 #368AFF
-  async function getDatas() {
-    fetch(
-      "http://apis.data.go.kr/6260000/FestivalService/getFestivalKr?serviceKey=ZlHtWroJ5vtZoCdZ24%2FYg25%2B%2F6l4ZCjrp19iGdmsJKQOng6tH28umr0KycuccrDvDy8ANWGyQHAO3iTL7Hdqyw%3D%3D&numOfRows=10&pageNo=1&resultType=json",
-      {
-        method: "GET",
-      }
-    )
-      .then((res) => {
-        //fetch를 통해 받아온 res객체 안에
-        //ok 프로퍼티가 있음
-        if (!res.ok) {
-          throw Error("could not fetch the data that resource");
-        }
-        return res.json();
-      })
-      .then((data) => {
-        const outputData = data.getFestivalKr.item.map((item, index) => {
-          return {
-            idxx: index,
-            X: String(item.LAT),
-            Y: String(item.LNG),
-            name: item.MAIN_TITLE || "",
-            date: item.USAGE_DAY_WEEK_AND_TIME?.trim() || "",
-            dateDetail: item.USAGE_DAY_WEEK_AND_TIME ? `일시 : ${item.USAGE_DAY_WEEK_AND_TIME.trim()}` : "",
-            src: item.MAIN_IMG_NORMAL || "",
-            alt: item.TITLE || "",
-            title: item.TITLE || "",
-            DateTime: item.USAGE_DAY_WEEK_AND_TIME || "",
-            place: item.MAIN_PLACE || item.PLACE || "",
-            text3: item.USAGE_AMOUNT ? `- 요금 : ${item.USAGE_AMOUNT}` : "- 요금 : 무료",
-            content: item.ITEMCNTNTS?.trim() || "",
-            text6: item.MIDDLE_SIZE_RM1 ? `- 편의시설 : ${item.MIDDLE_SIZE_RM1}` : ""
-          };
-        });
-        setDatas(outputData);
-        setTourinfo(outputData)
-      })
-      .catch((err) => {
-        alert(err.message);
-        //에러시 Loading메세지 사라지고
-        //에러메세지만 보이도록 설정
-      });
-  }
   useEffect(() => {
-    getDatas();
+    fetch(API_URL)
+      .then((r) => { if (!r.ok) throw new Error(); return r.json(); })
+      .then((data) => setDatas(data.response.body.items.item || []))
+      .catch(() => setDatas(tourinfo || []))
+      .finally(() => setLoading(false));
   }, []);
-  const divGroupStyle = {
-    position: "static",
-  };
-  const divStyle = {
-    display: "inline-block",
-    margin: "2rem 2rem",
-    padding: "10px",
-  };
-  const onClick = (month) => {
-    month==0 ?
-    setTempTourInfo(
-      tourinfo
-    ):
-    setTempTourInfo(
-      tourinfo.filter((info, i) => info.date.split(".")[1] * 1 == month)
-    );
-    
+
+  const handleClick = (item, i) => {
+    // 공공API 데이터는 상세 미지원, 정적 데이터(idxx 존재)만 상세 이동
+    if (item.idxx !== undefined) {
+      navigate(`/TourInfoDetail/${item.idxx}`);
+    }
   };
 
   return (
-    <>
-    <div style={styles.container}>
-        {datas.map((item) => (
-          <Link to={"/TourInfoDetail/" + item.idxx} key={item.idxx} className="no-underline">
-            <div key={item.idxx} style={styles.card}>
-              <img src={item.src} alt={item.title} style={styles.image} />
-              <div style={styles.text}>
-                <h3 style={styles.title}>{item.title}</h3>
-                <p style={styles.description}>{item.name}</p>
+    <div className="page-container">
+      <h2 className="section-title" style={{ marginBottom: "0.5rem" }}>축제 · 공연</h2>
+      <p style={{ color: "#888", fontSize: "0.9rem", marginBottom: "1.5rem" }}>
+        부산의 다양한 축제와 공연을 만나보세요.
+      </p>
+
+      {loading ? (
+        <div style={{ textAlign: "center", padding: "3rem", color: "#aaa" }}>불러오는 중...</div>
+      ) : (
+        <div className="tour-grid">
+          {datas.map((item, i) => (
+            <div
+              key={item.contentid || item.idxx || i}
+              className="tour-card"
+              onClick={() => handleClick(item, i)}
+              style={{ cursor: item.idxx !== undefined ? "pointer" : "default" }}
+            >
+              <img
+                src={item.firstimage || item.src || "https://via.placeholder.com/300x160?text=No+Image"}
+                alt={item.title}
+                onError={(e) => { e.target.src = "https://via.placeholder.com/300x160?text=No+Image"; }}
+              />
+              <div className="tour-card-body">
+                <p className="tour-card-title">{item.title}</p>
+                {item.addr1 && <p className="tour-card-sub">{item.addr1}</p>}
+                {item.date && <p className="tour-card-sub">{item.date}</p>}
               </div>
             </div>
-          </Link>
-        ))}
-      </div>
-      {/*month.map((m, i) => (
-        <button
-          key={i}
-          style={{
-            color: "white",
-            background: (i)==btnColor ? "#368AFF" : "#22B8CF",
-            padding: ".2rem .6rem",
-            margin: ".5rem",
-            border: "1px #22B8CF",
-            borderRadius: ".40rem",
-            fontSize: "1rem",
-            lineHeight: 1.5,
-            float: "center",
-          }}
-          onClick={() => {
-            onClick(i);
-            setBtnColor(i);
-          }}
-        >
-          <span>{m}</span>
-        </button>
-        ))*/}
-
-     {/*<div style={divGroupStyle}>
-        {tempTourInfo.map((i) => (
-          <div key={i.idxx} style={divStyle}>
-        
-            <Link to={"/TourInfoDetail/" + i.idxx} key={i.idxx}>
-              <p />
-              <img src={i.src} alt={i.alt} title={i.title} width={180} height={200}/>
-              <p />
-              <p />
-              <div style={{width:180}}>
-              {i.name}
-              </div>
-              <p />
-            </Link>
-        
-          </div>
-        ))}
-      
-        </div>*/}
-    </>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
-
-
-export default TourInfo;

--- a/src/pages/TourInfoDetail.js
+++ b/src/pages/TourInfoDetail.js
@@ -1,56 +1,52 @@
 import React from "react";
-import {
-  useParams,
-  useNavigate,
-} from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import Kakao from "../utils/Kakao";
 
-function TourInfoDetail({ tourinfo, setTourinfo }) {
-  const btnStyle = {
-    color: "white",
-    background: "#22B8CF",
-    padding: ".2rem .6rem",
-    margin: "0 auto",
-    display : "block",
-    border: "1px #22B8CF",
-    borderRadius: ".40rem",
-    fontSize: "1rem",
-    lineHeight: 1.5,
-    float: "center",
-  };
-  const screenStyle = {
-    padding: "3rem 3rem",
-    margin: "3rem 3rem",
-    float: "center",
-  };
-  const navigate = useNavigate();
+export default function TourInfoDetail({ tourinfo }) {
   const { idxx } = useParams();
-  let tmp = tourinfo.filter((info, i) => info.idxx == idxx)[0];
-  return (
-    <>
-      <div style={screenStyle}>
-        <h2>{tmp.title}</h2>
-        <p>{tmp.dateDetail}</p>
-        <img src={tmp.src} alt={tmp.alt} title={tmp.title} width={600} height={800}/>
-        <hr />
-        <p>
-          <h3>{tmp.name}</h3>
-        </p>
-        <p>- 일시 : {tmp.DateTime}</p>
-        <p>- 장소 : {tmp.place}</p>
-        <p>- 공연행사 : {tmp.content}</p>
-        <p>- 주최 : {tmp.organizedBy}</p>
-        <p>{tmp.text5}</p>
-        <p>{tmp.text6}</p>
-        {/*<Kakao X={tmp.X}Y={tmp.Y}/>*/}
-        <p>
-          <button style={btnStyle} onClick={() => navigate("/TourInfo")}>
-            목록
-          </button>
-        </p>
+  const navigate = useNavigate();
+
+  const item = tourinfo.find((info) => String(info.idxx) === String(idxx));
+
+  if (!item) {
+    return (
+      <div className="page-container" style={{ textAlign: "center", padding: "3rem" }}>
+        <p style={{ color: "#aaa" }}>정보를 찾을 수 없습니다.</p>
+        <button className="btn btn-primary" style={{ marginTop: "1rem" }} onClick={() => navigate("/TourInfo")}>
+          목록으로
+        </button>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <div className="page-container-sm" style={{ paddingBottom: "3rem" }}>
+      <h2 style={{ fontSize: "1.4rem", marginBottom: "0.4rem" }}>{item.title}</h2>
+      <p style={{ color: "#888", fontSize: "0.9rem", marginBottom: "1.2rem" }}>{item.dateDetail}</p>
+
+      <img
+        src={item.src}
+        alt={item.alt}
+        style={{ width: "100%", borderRadius: "10px", marginBottom: "1.5rem" }}
+      />
+
+      <hr className="divider" />
+
+      <h3 style={{ marginBottom: "1rem" }}>{item.name}</h3>
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem", color: "#444", lineHeight: 1.8 }}>
+        <p>- 일시 : {item.DateTime}</p>
+        <p>- 장소 : {item.place}</p>
+        <p>- 공연행사 : {item.content}</p>
+        {item.organizedBy && <p>- 주최 : {item.organizedBy}</p>}
+      </div>
+
+      <Kakao X={item.X} Y={item.Y} />
+
+      <div style={{ textAlign: "center", marginTop: "2rem" }}>
+        <button className="btn btn-primary" onClick={() => navigate("/TourInfo")}>
+          목록으로
+        </button>
+      </div>
+    </div>
   );
 }
-
-export default TourInfoDetail;

--- a/src/utils/Kakao.js
+++ b/src/utils/Kakao.js
@@ -1,27 +1,23 @@
+import React, { useEffect } from "react";
 
-import React ,{useEffect} from "react";
+function Kakao({ X, Y }) {
+  useEffect(() => {
+    if (!window.kakao || !window.kakao.maps) return;
 
-const { kakao } = window;
+    const container = document.getElementById("map");
+    const options = {
+      center: new window.kakao.maps.LatLng(X, Y),
+      level: 3,
+    };
+    new window.kakao.maps.Map(container, options);
+  }, [X, Y]);
 
-function Kakao ({ X, Y }){
-
-    useEffect(()=>{
-        const container = document.getElementById('map'); //지도를 담을 영역의 DOM 레퍼런스
-        const options = {
-            center: new kakao.maps.LatLng(X, Y), //지도의 중심좌표
-            level: 3 //지도 확대 레벨
-        };
-        new kakao.maps.Map(container, options); //지도 생성 및 객체 리턴
-
-    }, [])
-
-
-
-    return(
-        <div id="map" style={{
-            width: '1000px',
-            height: '500px'
-        }}></div>
-    )
+  return (
+    <div
+      id="map"
+      style={{ width: "100%", height: "400px", borderRadius: "10px", marginTop: "1.5rem" }}
+    />
+  );
 }
+
 export default Kakao;


### PR DESCRIPTION
▶ 홈 페이지 완성 (이미지 슬라이더 + 추천 투어 TOP3)

▶ 축제·공연 목록(TourInfo) + 상세(TourInfoDetail) + 카카오 지도